### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-gb 	KEYWORD3
+gb	KEYWORD3
 display	KEYWORD1
 tft	KEYWORD1
 sound	KEYWORD1
@@ -25,13 +25,13 @@ buttons	KEYWORD1
 lights	KEYWORD1
 save	KEYWORD1
 language	KEYWORD1
-gui KEYWORD1
+gui	KEYWORD1
 
 ////////////////////////core
 begin	KEYWORD1
 update	KEYWORD1
 frameCount	KEYWORD1
-getDefaultName KEYWORD1
+getDefaultName	KEYWORD1
 menu	KEYWORD1
 keyboard	KEYWORD1
 popup	KEYWORD1
@@ -45,70 +45,70 @@ released	KEYWORD1
 held	KEYWORD1
 repeat	KEYWORD1
 timeHeld	KEYWORD1
-BUTTON_A 	LITERAL1
-BUTTON_B 	LITERAL1
-BUTTON_MENU 	LITERAL1
-BUTTON_HOME 	LITERAL1
-BUTTON_UP 	LITERAL1
-BUTTON_RIGHT 	LITERAL1
-BUTTON_DOWN 	LITERAL1
-BUTTON_LEFT 	LITERAL1
+BUTTON_A	LITERAL1
+BUTTON_B	LITERAL1
+BUTTON_MENU	LITERAL1
+BUTTON_HOME	LITERAL1
+BUTTON_UP	LITERAL1
+BUTTON_RIGHT	LITERAL1
+BUTTON_DOWN	LITERAL1
+BUTTON_LEFT	LITERAL1
 
 ////////////////////////sound
-play	 KEYWORD1
-tone	 KEYWORD1
-playOK	 KEYWORD1
-playCancel	 KEYWORD1
-playTick	 KEYWORD1
-isPlaying	 KEYWORD1
-stop	 KEYWORD1
+play	KEYWORD1
+tone	KEYWORD1
+playOK	KEYWORD1
+playCancel	KEYWORD1
+playTick	KEYWORD1
+isPlaying	KEYWORD1
+stop	KEYWORD1
 
 ////////////////////////Display
 //general
-drawImage	 KEYWORD1
-drawBitmap	 KEYWORD1
-drawPixel	 KEYWORD1
-getPixelColor	 KEYWORD1
-getPixelIndex	 KEYWORD1
-fill	 KEYWORD1
-clear	 KEYWORD1
-clearTextVars	 KEYWORD1
-setColor	 KEYWORD1
-setTransparentColor	 KEYWORD1
-clearTransparentColor	 KEYWORD1
-getBitmapPixel	 KEYWORD1
-height	 KEYWORD1
-width	 KEYWORD1
+drawImage	KEYWORD1
+drawBitmap	KEYWORD1
+drawPixel	KEYWORD1
+getPixelColor	KEYWORD1
+getPixelIndex	KEYWORD1
+fill	KEYWORD1
+clear	KEYWORD1
+clearTextVars	KEYWORD1
+setColor	KEYWORD1
+setTransparentColor	KEYWORD1
+clearTransparentColor	KEYWORD1
+getBitmapPixel	KEYWORD1
+height	KEYWORD1
+width	KEYWORD1
 
 //text
-print	 KEYWORD1
-println	 KEYWORD1
-printf	 KEYWORD1
-drawChar	 KEYWORD1
-setFontSize	 KEYWORD1
-setTextWrap	 KEYWORD1
-setFont	 KEYWORD1
-setCursor	 KEYWORD1
-setCursorX	 KEYWORD1
-setCursorY	 KEYWORD1
-getTextBounds	 KEYWORD1
-getCursorX	 KEYWORD1
-getCursorY	 KEYWORD1
-getFontWidth	 KEYWORD1
-getFontHeight	 KEYWORD1
+print	KEYWORD1
+println	KEYWORD1
+printf	KEYWORD1
+drawChar	KEYWORD1
+setFontSize	KEYWORD1
+setTextWrap	KEYWORD1
+setFont	KEYWORD1
+setCursor	KEYWORD1
+setCursorX	KEYWORD1
+setCursorY	KEYWORD1
+getTextBounds	KEYWORD1
+getCursorX	KEYWORD1
+getCursorY	KEYWORD1
+getFontWidth	KEYWORD1
+getFontHeight	KEYWORD1
 
 //shapes
-drawLine	 KEYWORD1
-drawFastVLine	 KEYWORD1
-drawFastHLine	 KEYWORD1
-drawRect	 KEYWORD1
-fillRect	 KEYWORD1
-drawCircle	 KEYWORD1
-fillCircle	 KEYWORD1
-drawTriangle	 KEYWORD1
-fillTriangle	 KEYWORD1
-drawRoundRect	 KEYWORD1
-fillRoundRect	 KEYWORD1
+drawLine	KEYWORD1
+drawFastVLine	KEYWORD1
+drawFastHLine	KEYWORD1
+drawRect	KEYWORD1
+fillRect	KEYWORD1
+drawCircle	KEYWORD1
+fillCircle	KEYWORD1
+drawTriangle	KEYWORD1
+fillTriangle	KEYWORD1
+drawRoundRect	KEYWORD1
+fillRoundRect	KEYWORD1
 
 //colors
 WHITE	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords